### PR TITLE
Problem mit empty und isset behoben

### DIFF
--- a/widgets/DcaWizard.php
+++ b/widgets/DcaWizard.php
@@ -120,6 +120,20 @@ class DcaWizard extends \Widget
 
 
     /**
+     * Fix isset and empty problems with magic class variables
+     *
+     * @param $strKey
+     * @return bool
+     */
+    public function __isset($strKey)
+    {
+        $strValue = $this->__get($strKey);
+
+        return isset($strValue);
+    }
+
+
+    /**
      * Validate input
      */
     public function validate()


### PR DESCRIPTION
Ich habe ein Problem im DcaWizard entdeckt. Die empty() Funktion funktioniert nicht richtig, da die Klassenvariable `$this->params` übergeben wird. Dadurch findet kein merge mit `$arrParams` statt.

``` php
// Merge params
if (!empty($this->params) && is_array($this->params)) {
    $arrParams = array_merge($arrParams, $this->params);
}
```

Im Pull Request ist die Lösung für das Problem. Ich hoffe ihr könnt das in den Hotfix 2.1.1 übernehmen.
