### PR TITLE
Update DcaWizard.php

### DIFF
--- a/widgets/DcaWizard.php
+++ b/widgets/DcaWizard.php
@@ -118,6 +118,20 @@ class DcaWizard extends \Widget
         }
     }
 
+    /**
+     * magic getters are not called when checking with empty or isset. call magic getter first and then check
+     *
+     * @param string $strKey
+     *
+     * @return bool
+     */
+    public function __isset($strKey)
+    {
+        // first call __get to retrieve value...
+        $value = $this->{$strKey};
+        // ...then check if isset
+        return isset($value);
+    }
 
     /**
      * Validate input


### PR DESCRIPTION
Die IF-Condition in der Generate-Methode bei "Merge Params" trifft nie zu da eine empty-Abfrage bei magic getter properties leider immer true ergibt. Bei empty oder isset wird __get nicht aufgerufen und demnach ist dann die property nicht vorhanden. Eine Implementierung der __isset - Methode in der zunächst der magic getter aufgerufen wird und dann erst auf isset geprüft wird behebt das problem (empty() ruft intern zunächst isset() auf).
