### PR TITLE
Pass the necessary button parameters to callback

### DIFF
--- a/widgets/DcaWizard.php
+++ b/widgets/DcaWizard.php
@@ -224,9 +224,9 @@ class DcaWizard extends \Widget
 
         // Call a custom function instead of using the default button
         if (is_array($def['button_callback']))  {
-            return \System::importStatic($def['button_callback'][0])->{$def['button_callback'][1]}($row, $def['href'], $label, $title, $def['icon'], $attributes, $this->foreignTable);
+            return \System::importStatic($def['button_callback'][0])->{$def['button_callback'][1]}($row, $def['href'] . '&' . http_build_query($this->getButtonParams()), $label, $title, $def['icon'], $attributes, $this->foreignTable);
         } elseif (is_callable($def['button_callback'])) {
-            return $def['button_callback']($row, $def['href'], $label, $title, $def['icon'], $attributes, $this->foreignTable);
+            return $def['button_callback']($row, $def['href'] . '&' . http_build_query($this->getButtonParams()), $label, $title, $def['icon'], $attributes, $this->foreignTable);
         }
 
         return sprintf(

--- a/widgets/DcaWizard.php
+++ b/widgets/DcaWizard.php
@@ -224,9 +224,9 @@ class DcaWizard extends \Widget
 
         // Call a custom function instead of using the default button
         if (is_array($def['button_callback']))  {
-            return \System::importStatic($def['button_callback'][0])->{$def['button_callback'][1]}($row, $def['href'] . '&' . http_build_query($this->getButtonParams()), $label, $title, $def['icon'], $attributes, $this->foreignTable);
+            return \System::importStatic($def['button_callback'][0])->{$def['button_callback'][1]}($row, $def['href'] . '&amp;' . http_build_query($this->getButtonParams(), '', '&amp;'), $label, $title, $def['icon'], $attributes, $this->foreignTable);
         } elseif (is_callable($def['button_callback'])) {
-            return $def['button_callback']($row, $def['href'] . '&' . http_build_query($this->getButtonParams()), $label, $title, $def['icon'], $attributes, $this->foreignTable);
+            return $def['button_callback']($row, $def['href'] . '&amp;' . http_build_query($this->getButtonParams(), '', '&amp;'), $label, $title, $def['icon'], $attributes, $this->foreignTable);
         }
 
         return sprintf(


### PR DESCRIPTION
IMO the necessary button parameters should be passed to the button_callback.

This PR makes the dcawizard compatible with haste's ajax operations.

Sister PR codefog/contao-haste#142.