### PR TITLE
Fix wrong redirect after "saveNclose"

### DIFF
--- a/classes/DcaWizardHelper.php
+++ b/classes/DcaWizardHelper.php
@@ -123,6 +123,10 @@ class DcaWizardHelper
 
         $session = \Session::getInstance()->get('popupReferer');
 
+        if (!is_array($session) && version_compare(VERSION, '4.0', '>')) {
+            $session = \System::getContainer()->get('session')->getBag('contao_backend')->get('popupReferer');
+        }
+
         if (!is_array($session)) {
             return;
         }
@@ -151,6 +155,11 @@ class DcaWizardHelper
         }
 
         $session = \Session::getInstance()->get('popupReferer');
+
+        if (!is_array($session) && version_compare(VERSION, '4.0', '>')) {
+            $session = \System::getContainer()->get('session')->getBag('contao_backend')->get('popupReferer');
+        }
+
         $referer = \Session::getInstance()->get('dcaWizardReferer');
 
         if (!is_array($session) || !$referer) {


### PR DESCRIPTION
The problem is, that after clicking on "save and close" within the popup the redirect page is not necessarily the desired one.

**First**, there is a callback that handles this case and sets the correct referrer.
https://github.com/terminal42/contao-dcawizard/blob/810f3880ffc6e781dd0321d28d546a0dece8a7d0/classes/DcaWizardHelper.php#L115-L141

**Second**, this callback does not work, IF the session is not available (see lines 126-128).

**Third**, the Session::get('popupReferer') does not always return the appropriate session key.
https://github.com/contao/contao/blob/812ac06cd1c6f6c775e0dbca2547d89b3be36a2d/core-bundle/src/Resources/contao/library/Contao/Session.php#L100-L116

If we comment out lines 110-113, the session will be fetched from the value bag — the callback processes as desired.

I cannot say why the referer is in the bag in these cases 🙈
There has to be an issue of higher-order. I checked all occurrences of 'popupReferer' but I cannot determine, where the session persisting fails/is misconfigured.