### PR TITLE
Fix order of arguments for `AjaxActionsListener`

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -12,8 +12,8 @@ services:
 
     Terminal42\DcawizardBundle\EventListener\AjaxActionsListener:
         arguments:
-            - "@database_connection"
             - "@request_stack"
+            - "@database_connection"
 
     Terminal42\DcawizardBundle\EventListener\CloseModalListener:
         arguments:


### PR DESCRIPTION
The order of the constructor arguments for the AjaxActionsListener is incorrect. This leads to the following stack trace
```
TypeError:
Terminal42\DcawizardBundle\EventListener\AjaxActionsListener::__construct(): Argument #1 ($requestStack) must be of type Symfony\Component\HttpFoundation\RequestStack, Doctrine\DBAL\Connection given, called in /.../contao/var/cache/dev/ContainerQFHPGiE/getAjaxActionsListenerService.php on line 23

  at vendor/terminal42/dcawizard/src/EventListener/AjaxActionsListener.php:23
  at Terminal42\DcawizardBundle\EventListener\AjaxActionsListener->__construct()
     (var/cache/dev/ContainerQFHPGiE/getAjaxActionsListenerService.php:23)
  at ContainerQFHPGiE\getAjaxActionsListenerService::do()
     (var/cache/dev/ContainerQFHPGiE/Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer.php:1080)
  at ContainerQFHPGiE\Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer->load()
     (vendor/symfony/dependency-injection/Container.php:221)
  at Symfony\Component\DependencyInjection\Container::make()
     (vendor/symfony/dependency-injection/Container.php:203)
  at Symfony\Component\DependencyInjection\Container->get()
     (vendor/contao/core-bundle/contao/library/Contao/System.php:229)
  at Contao\System::importStatic()
     (vendor/contao/core-bundle/contao/classes/Ajax.php:424)
  at Contao\Ajax->executePostActionsHook()
     (vendor/contao/core-bundle/contao/classes/Ajax.php:407)
  at Contao\Ajax->executePostActions()
     (vendor/contao/core-bundle/contao/classes/Backend.php:311)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/contao/controllers/BackendMain.php:143)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/Backend/BackendController.php:45)
  at Contao\CoreBundle\Controller\Backend\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42)
```