### PR TITLE
Use Parent Table and Field to limit entry view

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,13 @@ These options are set directly on the field definition, outside of `eval`.
 
 #### Foreign Table Options
 
-| Option                  | Type     | Default | Description                                                              |
-|-------------------------|----------|---------|--------------------------------------------------------------------------|
-| `foreignTable`          | `string` | -       | The foreign database table to manage records from.                       |
-| `foreignField`          | `string` | `'pid'` | The foreign key field linking child records to the parent (e.g. `fid`).  |
-| `foreignTable_callback` | `array`  | -       | Callback to dynamically determine the foreign table name.                |
+| Option                  | Type     | Default | Description                                                                   |
+|-------------------------|----------|---------|-------------------------------------------------------------------------------|
+| `foreignTable`          | `string` | -       | The foreign database table to manage records from.                            |
+| `foreignField`          | `string` | `'pid'` | The foreign key field linking child records to the parent (e.g. `fid`).       |
+| `foreignTable_callback` | `array`  | -       | Callback to dynamically determine the foreign table name.                     |
+| `useParentTable`        | `bool`   | false   | Add the parent table name to the database field "ptable", limit backend view  |
+| `useParentField`        | `bool`   | false   | Add the parent field name to the database field "pfield", limit backend view  |
 
 #### URL Params Options
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,3 +19,8 @@ services:
         arguments:
             - "@request_stack"
             - "@router"
+
+    Terminal42\DcawizardBundle\EventListener\TableEditListener:
+      arguments:
+        - "@request_stack"
+        - "@database_connection"

--- a/src/EventListener/TableEditListener.php
+++ b/src/EventListener/TableEditListener.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\DcawizardBundle\EventListener;
+
+use Contao\Controller;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
+use Contao\CoreBundle\Exception\ResponseException;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\DataContainer;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+#[AsHook('loadDataContainer', priority: 10)]
+class TableEditListener
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function __invoke(string $dcaTable): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request || !$request->query->has('dcawizard')) {
+            return;
+        }
+
+        [$table] = explode(':', (string) $request->query->get('dcawizard')) + [null];
+
+        if ($table === $dcaTable) {
+            if (!$request->query->has('act') || 'edit' !== $request->query->get('act')) {
+                $ptable = $request->query->get('ptable');
+                $field = $request->query->get('field');
+
+                Controller::loadDataContainer($ptable);
+
+                $config = $GLOBALS['TL_DCA'][$ptable]['fields'][$field];
+
+                $useParentTable = $config['useParentTable'] ?? false;
+                $useParentField = $config['useParentField'] ?? false;
+
+                $filter = [];
+
+                if ($useParentTable) {
+                    $filter[] = ['ptable=?', $ptable];
+                }
+
+                if ($useParentField) {
+                    $filter[] = ['pfield=?', $field];
+                }
+
+                $GLOBALS['TL_DCA'][$table]['list']['sorting']['filter'] = $filter;
+            }
+
+            $GLOBALS['TL_DCA'][$table]['config']['onsubmit_callback'][] = $this->onSubmitTable(...);
+        }
+    }
+
+    private function onSubmitTable(DataContainer $dc): void
+    {
+        if (!$dc->id) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request && $request->query->has('dcawizard')) {
+            [$cTable] = explode(':', (string) $request->query->get('dcawizard')) + [null];
+
+            $table = $request->query->get('ptable');
+            $field = $request->query->get('field');
+
+            $config = $GLOBALS['TL_DCA'][$table]['fields'][$field];
+
+            $useParentTable = $config['useParentTable'] ?? false;
+            $useParentField = $config['useParentField'] ?? false;
+
+            $vars = [];
+            if ($useParentTable) {
+                $vars['ptable'] = $table;
+            }
+
+            if ($useParentField) {
+                $vars['pfield'] = $field;
+            }
+
+            if (count($vars)) {
+                $this->connection->update($cTable, $vars, ['id' => $dc->id]);
+            }
+        }
+    }
+}

--- a/src/Widget/DcaWizard.php
+++ b/src/Widget/DcaWizard.php
@@ -25,6 +25,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @property string        $foreignTable
  * @property string        $foreignField
  * @property callable|null $foreignTable_callback
+ * @property bool          $useParentTable
+ * @property bool          $useParentField
  * @property array         $headerFields
  * @property array         $fields
  * @property string        $editButtonLabel
@@ -83,6 +85,14 @@ class DcaWizard extends Widget
                 $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['foreignField'] = $varValue;
                 break;
 
+            case 'useParentTable':
+                $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['useParentTable'] = $varValue;
+                break;
+
+            case 'useParentField':
+                $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['useParentField'] = $varValue;
+                break;
+
             default:
                 parent::__set($strKey, $varValue);
                 break;
@@ -98,6 +108,8 @@ class DcaWizard extends Widget
             'foreignTable' => isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['foreignTable']),
             'foreignField' => true,
             'foreignTable_callback' => isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['foreignTable_callback']),
+            'useParentTable' => isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['useParentTable']),
+            'useParentField' => isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['useParentField']),
             default => parent::__get($strKey),
         };
     }
@@ -111,6 +123,8 @@ class DcaWizard extends Widget
             'foreignTable' => $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['foreignTable'] ?? null,
             'foreignField' => $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['foreignField'] ?? 'pid',
             'foreignTable_callback' => $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['foreignTable_callback'] ?? null,
+            'useParentTable' => $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['useParentTable'] ?? false,
+            'useParentField' => $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['useParentField'] ?? false,
             default => parent::__get($strKey),
         };
     }
@@ -532,6 +546,7 @@ class DcaWizard extends Widget
             'table' => $this->foreignTable,
             'field' => $this->strField,
             'id' => $this->currentRecord,
+            'ptable' => $this->strTable,
             'popup' => 1,
             'nb' => 1,
             'ref' => Input::get('ref'),
@@ -605,6 +620,11 @@ class DcaWizard extends Widget
 
         $strWhere = ' WHERE '.$foreignTableCondition;
 
+        if ($this->useParentField) {
+            $strWhere .= ' AND pfield=?';
+            $values[] = $this->strField;
+        }
+
         if ($this->whereCondition) {
             $strWhere .= ' AND '.$this->whereCondition;
         }
@@ -639,7 +659,7 @@ class DcaWizard extends Widget
         $where = "$this->foreignField=?";
         $values = [$this->currentRecord];
 
-        if (isset($GLOBALS['TL_DCA'][$this->foreignTable]['config']['dynamicPtable'])) {
+        if (isset($GLOBALS['TL_DCA'][$this->foreignTable]['config']['dynamicPtable']) || $this->useParentTable) {
             $where .= ' AND ptable=?';
             $values[] = $this->strTable;
         }


### PR DESCRIPTION
Adds new DCA configurations “useParentTable” and “useParentField” to display only DCA entries for the table and field. Allows adding multiple dcaWizard fields to a table.